### PR TITLE
Added exception for empty corpuses

### DIFF
--- a/exceptions.py
+++ b/exceptions.py
@@ -1,0 +1,3 @@
+class EmptyCorpusException(Exception):
+    """Raised when the user tries to initialize a retrieval algorithm with an empty corpus"""
+    pass

--- a/rank_bm25.py
+++ b/rank_bm25.py
@@ -4,6 +4,8 @@ import math
 import numpy as np
 from multiprocessing import Pool, cpu_count
 
+from exceptions import EmptyCorpusException
+
 """
 All of these algorithms have been taken from the paper:
 Trotmam et al, Improvements to BM25 and Language Models Examined
@@ -28,6 +30,8 @@ class BM25:
         self._calc_idf(nd)
 
     def _initialize(self, corpus):
+        if len(corpus) == 0:
+            raise EmptyCorpusException
         nd = {}  # word -> number of documents with word
         num_doc = 0
         for document in corpus:
@@ -43,7 +47,7 @@ class BM25:
 
             for word, freq in frequencies.items():
                 try:
-                    nd[word]+=1
+                    nd[word] += 1
                 except KeyError:
                     nd[word] = 1
 

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -1,3 +1,8 @@
+import sys
+import os
+myPath = os.path.dirname(os.path.abspath(__file__))
+sys.path.insert(0, myPath + '/../')
+
 import pytest
 
 from rank_bm25 import BM25

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -1,0 +1,10 @@
+import pytest
+
+from rank_bm25 import BM25
+from exceptions import EmptyCorpusException
+
+
+def test_empty_corpus():
+    """Make sure that correct Exception is thrown when any algorithm initializes with an empty corpus"""
+    with pytest.raises(EmptyCorpusException):
+        BM25([])


### PR DESCRIPTION
Adding custom exceptions to allow for better error handling. 

Currently only `EmptyCorpusException` has been implemented, but the framework for additional exceptions has been put in place to make it easier in the future.